### PR TITLE
認証方式を変更してローカルサーバ以外にも対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ comment-spawns:
 ## コマンド一覧
 - bougai
     - authorize  
-      YouTubeApiとの認証を行う  
+      YouTubeApiの認証URLを発行します
+    - authcode <認証URL>
+      発行した初回認証URLを使用して認証を行います  
       一度行うと認証情報が保存されるため初回のみ実行
     - start <配信URL> <プレイヤー名>  
       指定した配信を対象としてプラグインの動作を始める  

--- a/src/main/kotlin/me/gucchan/bougaiCraft/commands/BougaiCommand.kt
+++ b/src/main/kotlin/me/gucchan/bougaiCraft/commands/BougaiCommand.kt
@@ -1,6 +1,7 @@
 package me.gucchan.bougaiCraft.commands
 
 import me.gucchan.bougaiCraft.BougaiCraft
+import me.gucchan.bougaiCraft.commands.subcommands.AuthCodeCommand
 import me.gucchan.bougaiCraft.commands.subcommands.AuthorizeCommand
 import me.gucchan.bougaiCraft.commands.subcommands.ReloadCommand
 import me.gucchan.bougaiCraft.commands.subcommands.StartCommand
@@ -13,7 +14,8 @@ import org.bukkit.command.CommandSender
 class BougaiCommand(plugin: BougaiCraft) : CommandExecutor {
 
     private val subCommands = mapOf(
-        "authorize" to AuthorizeCommand(plugin, plugin.authManager),
+        "authorize" to AuthorizeCommand(plugin.authManager),
+        "authcode" to AuthCodeCommand(plugin),
         "start" to StartCommand(plugin),
         "stop" to StopCommand(plugin),
         "reload" to ReloadCommand(plugin),

--- a/src/main/kotlin/me/gucchan/bougaiCraft/commands/TabCompleter.kt
+++ b/src/main/kotlin/me/gucchan/bougaiCraft/commands/TabCompleter.kt
@@ -10,7 +10,7 @@ class TabCompleter : TabCompleter {
 
         when (args.size) {
             1 -> {
-                result.addAll(listOf("authorize", "start", "stop", "reload"))
+                result.addAll(listOf("authorize", "authcode", "start", "stop", "reload"))
                 result = result.filter {
                     it.startsWith(args[0])
                 }.toMutableList()
@@ -18,6 +18,10 @@ class TabCompleter : TabCompleter {
             2 if args[0] == "start" -> {
                 result.clear()
                 result.add("ライブ配信URL")
+            }
+            2 if args[0] == "authcode" -> {
+                result.clear()
+                result.add("認証画面URL")
             }
             3 if args[0] == "start" -> {
                 result.clear()

--- a/src/main/kotlin/me/gucchan/bougaiCraft/commands/subcommands/AuthCodeCommand.kt
+++ b/src/main/kotlin/me/gucchan/bougaiCraft/commands/subcommands/AuthCodeCommand.kt
@@ -1,0 +1,42 @@
+package me.gucchan.bougaiCraft.commands.subcommands
+
+import me.gucchan.bougaiCraft.BougaiCraft
+import me.gucchan.bougaiCraft.commands.SubCommand
+import me.gucchan.bougaiCraft.utils.UrlUtils
+import org.bukkit.Bukkit
+import org.bukkit.command.CommandSender
+
+class AuthCodeCommand(private val plugin: BougaiCraft) : SubCommand {
+    override fun execute(sender: CommandSender, args: Array<out String>) {
+        if (args.isEmpty()) {
+            sender.sendMessage("§c使い方: /bg authcode <認証画面URL>")
+            return
+        }
+
+        // URLにスペースが含まれて引数が分割された場合も考慮して、すべて結合する
+        val fullUrl = args.joinToString("")
+
+        // UrlUtilsを使ってURLから認証コードを抽出する
+        val code = UrlUtils.extractAuthCodeFromUrl(fullUrl)
+
+        if (code == null) {
+            sender.sendMessage("§cURLから認証コードが見つかりませんでした。正しいURLを貼り付けてください。")
+            return
+        }
+
+        sender.sendMessage("§e認証コードを処理しています...")
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+            try {
+                plugin.authManager.exchangeCodeForCredentials(code)
+                Bukkit.getScheduler().runTask(plugin, Runnable {
+                    sender.sendMessage("§a認証に成功しました！これで/bg startが使用できます。")
+                })
+            } catch (e: Exception) {
+                Bukkit.getScheduler().runTask(plugin, Runnable {
+                    sender.sendMessage("§c認証に失敗しました: ${e.message}")
+                })
+            }
+        })
+    }
+}

--- a/src/main/kotlin/me/gucchan/bougaiCraft/commands/subcommands/AuthorizeCommand.kt
+++ b/src/main/kotlin/me/gucchan/bougaiCraft/commands/subcommands/AuthorizeCommand.kt
@@ -2,11 +2,9 @@ package me.gucchan.bougaiCraft.commands.subcommands
 
 import me.gucchan.bougaiCraft.commands.SubCommand
 import me.gucchan.bougaiCraft.managers.YoutubeAuthManager
-import org.bukkit.Bukkit
 import org.bukkit.command.CommandSender
-import org.bukkit.plugin.java.JavaPlugin
 
-class AuthorizeCommand(private val plugin: JavaPlugin, private val authManager: YoutubeAuthManager) : SubCommand {
+class AuthorizeCommand(private val authManager: YoutubeAuthManager) : SubCommand {
 
     override fun execute(sender: CommandSender, args: Array<out String>) {
         if (args.isNotEmpty()) {
@@ -14,18 +12,15 @@ class AuthorizeCommand(private val plugin: JavaPlugin, private val authManager: 
             return
         }
 
-        sender.sendMessage("§eYouTubeの認証を開始します...")
-        sender.sendMessage("§eサーバーのコンソール（黒い画面）に表示されるURLにアクセスしてください。")
-
-        // 認証プロセスはサーバーをブロックする可能性があるので非同期で実行する
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
-            try {
-                authManager.authorize()
-                sender.sendMessage("§a認証が完了しました！")
-            } catch (_: Exception) {
-                sender.sendMessage("§c認証中にエラーが発生しました。コンソールを確認してください。")
-            }
-        })
-        return
+        try {
+            val authUrl = authManager.generateAuthUrl()
+            sender.sendMessage("§e==== YouTube認証 (ステップ1/2) ====")
+            sender.sendMessage("§7以下のURLにアクセスして認証を許可してください。")
+            sender.sendMessage("§b$authUrl") // URLを直接クリックできるよう、チャットに表示
+            sender.sendMessage("§7認証後、ブラウザのアドレスバーに表示されたURLを§cすべてコピー§7し、")
+            sender.sendMessage("§a/bg authcode <コピーしたURL> §7を実行してください。")
+        } catch (e: Exception) {
+            sender.sendMessage("§c認証URLの生成に失敗しました: ${e.message}")
+        }
     }
 }

--- a/src/main/kotlin/me/gucchan/bougaiCraft/managers/YoutubeAuthManager.kt
+++ b/src/main/kotlin/me/gucchan/bougaiCraft/managers/YoutubeAuthManager.kt
@@ -1,8 +1,6 @@
 package me.gucchan.bougaiCraft.managers
 
 import com.google.api.client.auth.oauth2.Credential
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.http.javanet.NetHttpTransport
@@ -12,19 +10,24 @@ import me.gucchan.bougaiCraft.BougaiCraft
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
+import java.io.IOException
 import java.io.InputStreamReader
 
 class YoutubeAuthManager(private val plugin: BougaiCraft) {
     private val jsonFactory = GsonFactory.getDefaultInstance()
     private val httpTransport = NetHttpTransport()
-    private val dataStoreFactory = FileDataStoreFactory(File(plugin.dataFolder, "credentials"))
+    private val credentialsFolder = File(plugin.dataFolder, "credentials")
+    private val dataStoreFactory = FileDataStoreFactory(credentialsFolder)
 
+    private val scopes = listOf("https://www.googleapis.com/auth/youtube.readonly")
     private val userIdentifier = "user"
+    private val redirectUri = "http://localhost:8888" // GCPで設定するリダイレクトURI
 
     /**
-     * ブラウザを使った認証フローを開始し、認証情報をファイルに保存する
+     * 認証フローのコアとなるGoogleAuthorizationCodeFlowオブジェクトを生成して返す。
+     * client_secrets.jsonが存在しない場合は例外をスローする。
      */
-    fun authorize() {
+    private fun getFlow(): GoogleAuthorizationCodeFlow {
         val clientSecretsFile = File(plugin.dataFolder, "client_secrets.json")
         // ファイルが存在しない場合のエラー処理
         if (!clientSecretsFile.exists()) {
@@ -40,33 +43,55 @@ class YoutubeAuthManager(private val plugin: BougaiCraft) {
             GoogleClientSecrets.load(jsonFactory, InputStreamReader(it))
         }
 
-        val flow = GoogleAuthorizationCodeFlow.Builder(
-            httpTransport, jsonFactory, clientSecrets,
-            listOf("https://www.googleapis.com/auth/youtube.readonly")
-        ).setDataStoreFactory(dataStoreFactory).build()
-
-        // コンソールにURLが表示され、ユーザーがブラウザで認証する
-        val receiver = LocalServerReceiver.Builder().setPort(8888).build()
-        AuthorizationCodeInstalledApp(flow, receiver).authorize(userIdentifier)
-        plugin.logger.info("認証に成功しました！認証情報は保存されました。")
+        return GoogleAuthorizationCodeFlow.Builder(httpTransport, jsonFactory, clientSecrets, scopes)
+            .setDataStoreFactory(dataStoreFactory)
+            .setAccessType("offline") // サーバー再起動後も使えるようにリフレッシュトークンを要求
+            .build()
     }
 
     /**
-     * 保存された認証情報を読み込む
+     * ステップ1: ユーザーがブラウザでアクセスするための認証URLを生成する。
+     * @return 生成された認証URL
+     */
+    fun generateAuthUrl(): String {
+        val flow = getFlow()
+        return flow.newAuthorizationUrl()
+            .setRedirectUri(redirectUri)
+            .build()
+    }
+
+    /**
+     * ステップ2: ユーザーがブラウザから取得した認証コードを、アクセストークンと交換してファイルに保存する。
+     * この処理はネットワーク通信を伴うため、非同期で実行する必要がある。
+     * @param code ブラウザのアドレスバーからコピーした認証コード
+     * @throws IOException 認証コードが無効な場合や、通信に失敗した場合
+     */
+    fun exchangeCodeForCredentials(code: String) {
+        val flow = getFlow()
+        try {
+            val response = flow.newTokenRequest(code)
+                .setRedirectUri(redirectUri)
+                .execute()
+
+            flow.createAndStoreCredential(response, userIdentifier)
+        } catch (e: IOException) {
+            // エラーの詳細をラップして、より分かりやすいメッセージを添えて再スローする
+            throw IOException("無効な認証コード、または認証プロセスでエラーが発生しました。", e)
+        }
+    }
+
+    /**
+     * 保存済みの認証情報(Credential)をファイルから読み込む。
+     * 認証が完了していない、またはファイルが見つからない場合はnullを返す。
+     * @return 読み込んだCredentialオブジェクト、またはnull
      */
     fun loadCredentials(): Credential? {
-        val clientSecretsFile = File(plugin.dataFolder, "client_secrets.json")
-        if (!clientSecretsFile.exists()) return null
-
-        val clientSecrets = FileInputStream(clientSecretsFile).use {
-            GoogleClientSecrets.load(jsonFactory, InputStreamReader(it))
+        return try {
+            getFlow().loadCredential(userIdentifier)
+        } catch (e: Exception) {
+            // client_secrets.jsonが見つからない場合など
+            plugin.logger.warning("認証情報の読み込みに失敗しました: ${e.message}")
+            null
         }
-
-        val flow = GoogleAuthorizationCodeFlow.Builder(
-            httpTransport, jsonFactory, clientSecrets,
-            listOf("https://www.googleapis.com/auth/youtube.readonly")
-        ).setDataStoreFactory(dataStoreFactory).build()
-
-        return flow.loadCredential(userIdentifier)
     }
 }

--- a/src/main/kotlin/me/gucchan/bougaiCraft/utils/UrlUtils.kt
+++ b/src/main/kotlin/me/gucchan/bougaiCraft/utils/UrlUtils.kt
@@ -14,4 +14,17 @@ object UrlUtils {
         // マッチ結果から1番目のキャプチャグループ（Video ID部分）を返す
         return matchResult?.groupValues?.get(1)
     }
+
+    /**
+     * リダイレクトURLから 'code' パラメータの値を抽出する
+     * @param url ブラウザのアドレスバーに表示されたURL全体
+     * @return 抽出した認証コード。見つからなければnullを返す
+     */
+    fun extractAuthCodeFromUrl(url: String): String? {
+        // パターン: 「?code=」または「&code=」の直後から始まり、'&'以外の文字の連続
+        val pattern = """(?<=[?&]code=)[^&]+""".toRegex()
+
+        // .find()で見つかった最初のマッチオブジェクトを取得し、その.value（値そのもの）を返す
+        return pattern.find(url)?.value
+    }
 }


### PR DESCRIPTION
https://github.com/yamayama250/BougaiCraft/issues/11

- 認証URLの発行と認証作業を分けて実行するように
- 認証方式の変更に伴い、コマンドの追加
- READMEの更新